### PR TITLE
Down sample depth when depth buf > GTAV window

### DIFF
--- a/database_schema.sql
+++ b/database_schema.sql
@@ -1,0 +1,200 @@
+create type detection_type AS ENUM ('background', 'person', 'car', 'bicycle');
+
+create type detection_class AS ENUM ('Unknown',   'Compacts',   'Sedans',   'SUVs',   'Coupes',   'Muscle',   'SportsClassics',   'Sports',   'Super',   'Motorcycles',   'OffRoad',   'Industrial',   'Utility',   'Vans',   'Cycles',   'Boats',   'Helicopters',   'Planes',   'Service',   'Emergency',   'Military',   'Commercial',   'Trains');
+
+create type weather AS ENUM ('Unknown', 'ExtraSunny', 'Clear', 'Clouds', 'Smog', 'Foggy', 'Overcast', 'Raining', 'ThunderStorm', 'Clearing', 'Neutral', 'Snowing', 'Blizzard', 'Snowlight', 'Christmas', 'Halloween');
+
+create table detections
+(
+	detection_id serial not null
+		constraint detections_pkey
+			primary key,
+	snapshot_id integer,
+	type detection_type,
+	pos geometry(PointZ),
+	bbox box,
+	class detection_class default 'Unknown'::detection_class,
+	handle integer default '-1'::integer,
+	best_bbox box,
+	best_bbox_old box,
+	bbox3d box3d,
+	rot geometry,
+	coverage real default 0.0,
+    created timestamp without time zone default (now() at time zone 'utc')
+)
+;
+
+
+create table runs
+(
+	run_id serial not null
+		constraint runs_pkey
+			primary key,
+	runguid uuid,
+	archivepath text,
+	localpath text,
+	session_id integer default 1,
+	instance_id integer default 0,
+    created timestamp without time zone default (now() at time zone 'utc')
+)
+;
+
+
+create table sessions
+(
+	session_id serial not null
+		constraint sessions_pkey
+			primary key,
+	name text
+		constraint sessions_name_key
+			unique,
+	start timestamp with time zone,
+	"end" timestamp with time zone,
+    created timestamp without time zone default (now() at time zone 'utc')
+)
+;
+
+alter table runs
+	add constraint runs_session_fkey
+		foreign key (session_id) references sessions
+			on delete cascade
+;
+
+create table snapshots
+(
+	snapshot_id serial not null
+		constraint snapshots_pkey
+			primary key,
+	run_id integer
+		constraint snapshots_run_fkey
+			references runs
+				on delete cascade,
+	version integer,
+	imagepath text,
+	timestamp timestamp with time zone,
+	timeofday time,
+	currentweather weather,
+	camera_pos geometry(PointZ),
+	camera_direction geometry,
+	camera_fov real,
+	view_matrix double precision[],
+	proj_matrix double precision[],
+	processed boolean default false not null,
+	width integer,
+	height integer
+)
+;
+
+
+alter table detections
+	add constraint detections_snapshot_fkey
+		foreign key (snapshot_id) references snapshots
+			on delete cascade
+;
+
+create table instances
+(
+	instance_id serial not null
+		constraint isntances_pkey
+			primary key,
+	hostname text,
+	instanceid text
+		constraint instanceid_uniq
+			unique,
+	instancetype text,
+	publichostname text,
+	amiid text,
+    created timestamp without time zone default (now() at time zone 'utc'),
+	constraint instance_info_uniq
+		unique (hostname, instanceid, instancetype, publichostname, amiid)
+)
+;
+
+alter table runs
+	add constraint runs_instance_fkey
+		foreign key (instance_id) references instances
+;
+
+create table snapshot_weathers
+(
+	weather_id serial not null
+		constraint snapshot_weathers_pkey
+			primary key,
+	snapshot_id integer
+		constraint snapshot_weathers_snapshot_id_fkey
+			references snapshots
+				on delete cascade,
+	weather_type weather,
+	snapshot_page integer,
+    created timestamp without time zone default (now() at time zone 'utc')
+)
+;
+
+create table uploads
+(
+	id serial not null
+		constraint uploads_pkey
+			primary key,
+	bucket text,
+	key text,
+	uploadid text,
+    created timestamp without time zone default (now() at time zone 'utc')
+)
+;
+
+create table datasets
+(
+	dataset_id serial not null
+		constraint datasets_pkey
+			primary key,
+	dataset_name text,
+	view_name text,
+    created timestamp without time zone default (now() at time zone 'utc')
+)
+;
+
+create table systems
+(
+	system_uuid uuid not null
+		constraint systems_pkey
+			primary key,
+	vendor text,
+	dnshostname text,
+	username text,
+	systemtype text,
+	totalmem bigint,
+    created timestamp without time zone default (now() at time zone 'utc')
+)
+;
+
+create table system_graphics
+(
+	system_graphic_id serial not null
+		constraint system_graphics_pkey
+			primary key,
+	deviceid text,
+	adaptercompatibility text,
+	adapterdactype text,
+	adapterram integer,
+	availability integer,
+	caption text,
+	description text,
+	driverdate timestamp with time zone,
+	driverversion text,
+	pnpdeviceid text,
+	name text,
+	videoarch integer,
+	memtype integer,
+	videoprocessor text,
+	bpp integer,
+	hrez integer,
+	vrez integer,
+	num_colors integer,
+	cols integer,
+	rows integer,
+	refresh integer,
+	scanmode integer,
+	videomodedesc text,
+    created timestamp without time zone default (now() at time zone 'utc')
+)
+;

--- a/managed/GTAVisionExport/GTAVisionExport.csproj
+++ b/managed/GTAVisionExport/GTAVisionExport.csproj
@@ -74,9 +74,8 @@
     <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.1.1.0\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="NativeUI, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>G:\games\SteamLibrary\steamapps\common\Grand Theft Auto V\scripts\NativeUI.dll</HintPath>
+    <Reference Include="NativeUI">
+      <HintPath>C:\Program Files\Rockstar Games\Grand Theft Auto V\Scripts\NativeUI.dll</HintPath>
     </Reference>
     <Reference Include="Npgsql, Version=3.2.1.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
       <HintPath>..\packages\Npgsql.3.2.1\lib\net451\Npgsql.dll</HintPath>
@@ -84,10 +83,7 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="ScriptHookVDotNet2">
-      <HintPath>..\..\..\..\..\Program Files (x86)\SteamLibrary\steamapps\common\Grand Theft Auto V\ScriptHookVDotNet2.dll</HintPath>
-    </Reference>
-    <Reference Include="ScriptHookVDotNet2, Version=2.10.3.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>D:\Program Files (x86)\SteamLibrary\steamapps\common\Grand Theft Auto V\ScriptHookVDotNet2.dll</HintPath>
+      <HintPath>C:\Program Files\Rockstar Games\Grand Theft Auto V\ScriptHookVDotNet2.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -113,10 +109,10 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="VAutodrive">
-      <HintPath>G:\games\SteamLibrary\steamapps\common\Grand Theft Auto V\scripts\VAutodrive.dll</HintPath>
+      <HintPath>C:\Program Files\Rockstar Games\Grand Theft Auto V\Scripts\VAutodrive.dll</HintPath>
     </Reference>
     <Reference Include="VCommonFunctions">
-      <HintPath>G:\games\SteamLibrary\steamapps\common\Grand Theft Auto V\scripts\VCommonFunctions.dll</HintPath>
+      <HintPath>C:\Program Files\Rockstar Games\Grand Theft Auto V\Scripts\VCommonFunctions.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="YamlDotNet, Version=4.1.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/managed/GTAVisionExport/VisionExport.cs
+++ b/managed/GTAVisionExport/VisionExport.cs
@@ -67,6 +67,7 @@ namespace GTAVisionExport {
         private speedAndTime lowSpeedTime = new speedAndTime();
         private bool IsGamePaused = false;
         private StereoCamera cams;
+		private bool notificationsEnabled = true;
         public VisionExport()
         {
             // loading ini file
@@ -105,9 +106,9 @@ namespace GTAVisionExport {
         private void handlePipeInput()
         {
             System.IO.File.AppendAllText(logFilePath, "VisionExport handlePipeInput called.\n");
-            UI.Notify("handlePipeInput called");
-            UI.Notify("server connected:" + server.Connected.ToString());
-            UI.Notify(connection == null ? "connection is null" : "connection:" + connection.ToString());
+            if(notificationsEnabled) UI.Notify("handlePipeInput called");
+			if (notificationsEnabled) UI.Notify("server connected:" + server.Connected.ToString());
+			if (notificationsEnabled) UI.Notify(connection == null ? "connection is null" : "connection:" + connection.ToString());
             if (connection == null) return;
             
             byte[] inBuffer = new byte[1024];
@@ -133,7 +134,7 @@ namespace GTAVisionExport {
                 connection = null;
                 return;
             }
-            UI.Notify(str.Length.ToString());
+			if (notificationsEnabled) UI.Notify(str.Length.ToString());
             switch (str)
             {
                 case "START_SESSION":
@@ -150,7 +151,7 @@ namespace GTAVisionExport {
                     ToggleNavigation();
                     break;
                 case "ENTER_VEHICLE":
-                    UI.Notify("Trying to enter vehicle");
+					if (notificationsEnabled) UI.Notify("Trying to enter vehicle");
                     EnterVehicle();
                     break;
                 case "AUTOSTART":
@@ -219,7 +220,7 @@ namespace GTAVisionExport {
             if (server.Poll(10, SelectMode.SelectRead) && connection == null)
             {
                 connection = server.Accept();
-                UI.Notify("CONNECTED");
+				if (notificationsEnabled) UI.Notify("CONNECTED");
                 connection.Blocking = false;
             }
             handlePipeInput();
@@ -234,9 +235,9 @@ namespace GTAVisionExport {
                     StopRun();
                     runTask?.Wait();
                     runTask = StartRun();
-                    //StopSession();
-                    //Autostart();
-                    UI.Notify("need reload game");
+					//StopSession();
+					//Autostart();
+					if (notificationsEnabled) UI.Notify("need reload game");
                     Script.Wait(100);
                     ReloadGame();
                     break;
@@ -284,11 +285,11 @@ namespace GTAVisionExport {
             var colorframe = VisionNative.GetLastColorTime();
             var depthframe = VisionNative.GetLastConstantTime();
             var constantframe = VisionNative.GetLastConstantTime();
-            //UI.Notify("DIFF: " + (colorframe - depthframe) + " FRAMETIME: " + (1 / Game.FPS) * 1000);
-            UI.Notify(colors[0].Length.ToString());
+			//UI.Notify("DIFF: " + (colorframe - depthframe) + " FRAMETIME: " + (1 / Game.FPS) * 1000);
+			if (notificationsEnabled) UI.Notify(colors[0].Length.ToString());
             if (depth == null || stencil == null)
             {
-                UI.Notify("No DEPTH");
+				if (notificationsEnabled) UI.Notify("No DEPTH");
                 return;
             }
 
@@ -499,24 +500,39 @@ namespace GTAVisionExport {
         public void OnKeyDown(object o, KeyEventArgs k)
         {
             System.IO.File.AppendAllText(logFilePath, "VisionExport OnKeyDown called.\n");
+
+			if (k.KeyCode == Keys.Z)
+			{
+				if (notificationsEnabled)
+				{
+					UI.Notify("Notifications Disabled");
+					notificationsEnabled = false;
+				}
+				else
+				{
+					UI.Notify("Notifications Enabled");
+					notificationsEnabled = true;
+
+				}
+			}
             if (k.KeyCode == Keys.PageUp)
             {
                 postgresTask?.Wait();
                 postgresTask = StartSession();
                 runTask?.Wait();
                 runTask = StartRun();
-                UI.Notify("GTA Vision Enabled");
+				if (notificationsEnabled) UI.Notify("GTA Vision Enabled");
             }
             if (k.KeyCode == Keys.PageDown)
             {
                 StopRun();
                 StopSession();
-                UI.Notify("GTA Vision Disabled");
+				if (notificationsEnabled) UI.Notify("GTA Vision Disabled");
             }
             if (k.KeyCode == Keys.H) // temp modification
             {
                 EnterVehicle();
-                UI.Notify("Trying to enter vehicle");
+				if (notificationsEnabled) UI.Notify("Trying to enter vehicle");
                 ToggleNavigation();
             }
             if (k.KeyCode == Keys.Y) // temp modification
@@ -530,7 +546,7 @@ namespace GTAVisionExport {
 
                 //UI.Notify(ConfigurationManager.AppSettings["database_connection"]);
                 var str = settings.GetValue("", "ConnectionString");
-                UI.Notify(loc);
+				if (notificationsEnabled) UI.Notify(loc);
 
             }
             if (k.KeyCode == Keys.G) // temp modification
@@ -580,7 +596,7 @@ namespace GTAVisionExport {
                 /* set it between 0 = stop, 1 = heavy rain. set it too high will lead to sloppy ground */
                 Function.Call(GTA.Native.Hash._SET_RAIN_FX_INTENSITY, 0.5f);
                 var test = Function.Call<float>(GTA.Native.Hash.GET_RAIN_LEVEL);
-                UI.Notify("" + test);
+				if (notificationsEnabled) UI.Notify("" + test);
                 World.CurrentDayTime = new TimeSpan(12, 0, 0);
                 //Script.Wait(5000);
             }
@@ -634,7 +650,7 @@ namespace GTAVisionExport {
                     var t = Tiff.Open(Path.Combine(dataPath, "info" + i.ToString() + ".tiff"), "w");
                     ImageUtils.WriteToTiff(t, res.Width, res.Height, colors, depth, stencil);
                     t.Close();
-                    UI.Notify(GameplayCamera.FieldOfView.ToString());
+					if (notificationsEnabled) UI.Notify(GameplayCamera.FieldOfView.ToString());
                     //UI.Notify((connection != null && connection.Connected).ToString());
 
 
@@ -681,8 +697,8 @@ namespace GTAVisionExport {
             if (k.KeyCode == Keys.I)
             {
                 var info = new GTAVisionUtils.InstanceData();
-                UI.Notify(info.type);
-                UI.Notify(info.publichostname);
+				if (notificationsEnabled) UI.Notify(info.type);
+				if (notificationsEnabled) UI.Notify(info.publichostname);
             }
         }
     }

--- a/managed/GTAVisionExport/VisionExport.cs
+++ b/managed/GTAVisionExport/VisionExport.cs
@@ -47,8 +47,7 @@ namespace GTAVisionExport {
 #endif
         //private readonly string dataPath =
         //    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Data");
-        private readonly string dataPath;
-        private readonly string logFilePath;
+        private readonly string dataPath = @"Z:\archives\";
         private readonly Weather[] wantedWeather = new Weather[] {Weather.Clear, Weather.Clouds, Weather.Overcast, Weather.Raining, Weather.Christmas};
         private Player player;
         private string outputPath;
@@ -67,22 +66,8 @@ namespace GTAVisionExport {
         private speedAndTime lowSpeedTime = new speedAndTime();
         private bool IsGamePaused = false;
         private StereoCamera cams;
-		private bool notificationsOn = true;
-		private bool vAutodriveEnabled = true;
-
-		public VisionExport()
+        public VisionExport()
         {
-            // loading ini file
-            var parser = new FileIniDataParser();
-            var location = AppDomain.CurrentDomain.BaseDirectory;
-            var data = parser.ReadFile(Path.Combine(location, "GTAVision.ini"));
-
-            //UINotify(ConfigurationManager.AppSettings["database_connection"]);
-            dataPath = data["Snapshots"]["OutputDir"];
-            logFilePath = data["Snapshots"]["LogFile"];
-			//System.IO.File.WriteAllText("d:/Snapshots/data.txt", data.ToString());
-
-			System.IO.File.WriteAllText(logFilePath, "VisionExport constructor called.\n");
             if (!Directory.Exists(dataPath)) Directory.CreateDirectory(dataPath);
             PostgresExport.InitSQLTypes();
             player = Game.Player;
@@ -90,6 +75,12 @@ namespace GTAVisionExport {
             server.Bind(new IPEndPoint(IPAddress.Loopback, 5555));
             server.Listen(5);
             //server = new UdpClient(5555);
+            var parser = new FileIniDataParser();
+            var location = AppDomain.CurrentDomain.BaseDirectory;
+            var data = parser.ReadFile(Path.Combine(location, "GTAVision.ini"));
+            var access_key = data["aws"]["access_key"];
+            var secret_key = data["aws"]["secret_key"];
+            //client = new AmazonS3Client(new BasicAWSCredentials(access_key, secret_key), RegionEndpoint.USEast1);
             //outputPath = @"D:\Datasets\GTA\";
             //outputPath = Path.Combine(outputPath, "testData.yaml");
             //outStream = File.CreateText(outputPath);
@@ -108,10 +99,7 @@ namespace GTAVisionExport {
 
         private void handlePipeInput()
         {
-            System.IO.File.AppendAllText(logFilePath, "VisionExport handlePipeInput called.\n");
-			if (notificationsOn) UI.Notify("handlePipeInput called");
-			if (notificationsOn) UI.Notify("server connected:" + server.Connected.ToString());
-			if (notificationsOn) UI.Notify(connection == null ? "connection is null" : "connection:" + connection.ToString());
+            //UI.Notify(server.Available.ToString());
             if (connection == null) return;
             
             byte[] inBuffer = new byte[1024];
@@ -137,7 +125,7 @@ namespace GTAVisionExport {
                 connection = null;
                 return;
             }
-			if (notificationsOn) UI.Notify(str.Length.ToString());
+            UI.Notify(str.Length.ToString());
             switch (str)
             {
                 case "START_SESSION":
@@ -154,7 +142,7 @@ namespace GTAVisionExport {
                     ToggleNavigation();
                     break;
                 case "ENTER_VEHICLE":
-					if (notificationsOn) UI.Notify("Trying to enter vehicle");
+                    UI.Notify("Trying to enter vehicle");
                     EnterVehicle();
                     break;
                 case "AUTOSTART":
@@ -223,7 +211,7 @@ namespace GTAVisionExport {
             if (server.Poll(10, SelectMode.SelectRead) && connection == null)
             {
                 connection = server.Accept();
-				if (notificationsOn) UI.Notify("CONNECTED");
+                UI.Notify("CONNECTED");
                 connection.Blocking = false;
             }
             handlePipeInput();
@@ -238,9 +226,9 @@ namespace GTAVisionExport {
                     StopRun();
                     runTask?.Wait();
                     runTask = StartRun();
-					//StopSession();
-					//Autostart();
-					if (notificationsOn) UI.Notify("need reload game");
+                    //StopSession();
+                    //Autostart();
+                    UI.Notify("need reload game");
                     Script.Wait(100);
                     ReloadGame();
                     break;
@@ -288,8 +276,8 @@ namespace GTAVisionExport {
             var colorframe = VisionNative.GetLastColorTime();
             var depthframe = VisionNative.GetLastConstantTime();
             var constantframe = VisionNative.GetLastConstantTime();
-			//UI.Notify("DIFF: " + (colorframe - depthframe) + " FRAMETIME: " + (1 / Game.FPS) * 1000);
-			if (notificationsOn) UI.Notify(colors[0].Length.ToString());
+            //UI.Notify("DIFF: " + (colorframe - depthframe) + " FRAMETIME: " + (1 / Game.FPS) * 1000);
+            UI.Notify(colors[0].Length.ToString());
             if (depth == null || stencil == null)
             {
                 UI.Notify("No DEPTH");
@@ -454,12 +442,9 @@ namespace GTAVisionExport {
 
         public void ToggleNavigation()
         {
-			//YOLO
-			if (vAutodriveEnabled)
-			{
-				MethodInfo inf = kh.GetType().GetMethod("AtToggleAutopilot", BindingFlags.NonPublic | BindingFlags.Instance);
-				inf.Invoke(kh, new object[] { new KeyEventArgs(Keys.J) });
-			}
+            //YOLO
+            MethodInfo inf = kh.GetType().GetMethod("AtToggleAutopilot", BindingFlags.NonPublic | BindingFlags.Instance);
+            inf.Invoke(kh, new object[] {new KeyEventArgs(Keys.J)});
         }
 
         public void ReloadGame()
@@ -505,52 +490,24 @@ namespace GTAVisionExport {
 
         public void OnKeyDown(object o, KeyEventArgs k)
         {
-            System.IO.File.AppendAllText(logFilePath, "VisionExport OnKeyDown called.\n");
-			if(k.KeyCode == Keys.Z)
-			{
-				if(notificationsOn == true)
-				{
-					notificationsOn = false;
-					UI.Notify("Notifications Disabled");
-				}
-				else
-				{
-					notificationsOn = true;
-					UI.Notify("Notifications Enabled");
-				}
-			}
-			if (k.KeyCode == Keys.A)
-			{
-				if (vAutodriveEnabled == true)
-				{
-					vAutodriveEnabled = false;
-					UI.Notify("VAutodrive Disabled");
-				}
-				else
-				{
-					vAutodriveEnabled = true;
-					UI.Notify("VAutodrive Enabled");
-				}
-			}
-			if (k.KeyCode == Keys.PageUp)
+            if (k.KeyCode == Keys.PageUp)
             {
                 postgresTask?.Wait();
                 postgresTask = StartSession();
                 runTask?.Wait();
                 runTask = StartRun();
-				if (notificationsOn) UI.Notify("GTA Vision Enabled");
-
+                UI.Notify("GTA Vision Enabled");
             }
             if (k.KeyCode == Keys.PageDown)
             {
                 StopRun();
                 StopSession();
-				if (notificationsOn) UI.Notify("GTA Vision Disabled");
+                UI.Notify("GTA Vision Disabled");
             }
             if (k.KeyCode == Keys.H) // temp modification
             {
                 EnterVehicle();
-				if (notificationsOn) UI.Notify("Trying to enter vehicle");
+                UI.Notify("Trying to enter vehicle");
                 ToggleNavigation();
             }
             if (k.KeyCode == Keys.Y) // temp modification
@@ -564,7 +521,7 @@ namespace GTAVisionExport {
 
                 //UI.Notify(ConfigurationManager.AppSettings["database_connection"]);
                 var str = settings.GetValue("", "ConnectionString");
-				if (notificationsOn) UI.Notify(loc);
+                UI.Notify(loc);
 
             }
             if (k.KeyCode == Keys.G) // temp modification
@@ -580,15 +537,15 @@ namespace GTAVisionExport {
                 */
                 var data = GTAData.DumpData(Game.GameTime + ".tiff", new List<Weather>(wantedWeather));
 
-				//string path = @"C:\Users\NGV-02\Documents\Data\trymatrix.txt";
-				string path = @"D:\Snapshots\trymatrix.txt";
-				// This text is added only once to the file.
-				if (!File.Exists(path))
+                string path = @"C:\Users\NGV-02\Documents\Data\trymatrix.txt";
+                // This text is added only once to the file.
+                if (!File.Exists(path))
                 {
                     // Create a file to write to.
                     using (StreamWriter file = File.CreateText(path))
                     {
-
+                        
+                        
                         file.WriteLine("cam direction file");
                         file.WriteLine("direction:");
                         file.WriteLine(GameplayCamera.Direction.X.ToString() + ' ' + GameplayCamera.Direction.Y.ToString() + ' ' + GameplayCamera.Direction.Z.ToString());
@@ -614,7 +571,7 @@ namespace GTAVisionExport {
                 /* set it between 0 = stop, 1 = heavy rain. set it too high will lead to sloppy ground */
                 Function.Call(GTA.Native.Hash._SET_RAIN_FX_INTENSITY, 0.5f);
                 var test = Function.Call<float>(GTA.Native.Hash.GET_RAIN_LEVEL);
-				if (notificationsOn) UI.Notify("" + test);
+                UI.Notify("" + test);
                 World.CurrentDayTime = new TimeSpan(12, 0, 0);
                 //Script.Wait(5000);
             }
@@ -668,16 +625,15 @@ namespace GTAVisionExport {
                     var t = Tiff.Open(Path.Combine(dataPath, "info" + i.ToString() + ".tiff"), "w");
                     ImageUtils.WriteToTiff(t, res.Width, res.Height, colors, depth, stencil);
                     t.Close();
-					if (notificationsOn) UI.Notify(GameplayCamera.FieldOfView.ToString());
+                    UI.Notify(GameplayCamera.FieldOfView.ToString());
                     //UI.Notify((connection != null && connection.Connected).ToString());
 
 
                     var data = GTAData.DumpData(Game.GameTime + ".dat", new List<Weather>(wantedWeather));
 
-                    //string path = @"C:\Users\NGV-02\Documents\Data\info.txt";
-					string path = @"D:\Snapshots\info.txt";
-					// This text is added only once to the file.
-					if (!File.Exists(path))
+                    string path = @"C:\Users\NGV-02\Documents\Data\info.txt";
+                    // This text is added only once to the file.
+                    if (!File.Exists(path))
                     {
                         // Create a file to write to.
                         using (StreamWriter file = File.CreateText(path))
@@ -716,8 +672,8 @@ namespace GTAVisionExport {
             if (k.KeyCode == Keys.I)
             {
                 var info = new GTAVisionUtils.InstanceData();
-				if (notificationsOn) UI.Notify(info.type);
-				if (notificationsOn) UI.Notify(info.publichostname);
+                UI.Notify(info.type);
+                UI.Notify(info.publichostname);
             }
         }
     }

--- a/managed/GTAVisionUtils/GTAVisionUtils.csproj
+++ b/managed/GTAVisionUtils/GTAVisionUtils.csproj
@@ -66,7 +66,7 @@
       <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.1.1.0\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="NativeUI">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Grand Theft Auto V\scripts\NativeUI.dll</HintPath>
+      <HintPath>C:\Program Files\Rockstar Games\Grand Theft Auto V\Scripts\NativeUI.dll</HintPath>
     </Reference>
     <Reference Include="Npgsql, Version=3.2.1.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
       <HintPath>..\packages\Npgsql.3.2.1\lib\net451\Npgsql.dll</HintPath>
@@ -80,10 +80,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="ScriptHookVDotNet2">
-      <HintPath>..\..\..\..\..\Program Files (x86)\SteamLibrary\steamapps\common\Grand Theft Auto V\ScriptHookVDotNet2.dll</HintPath>
-    </Reference>
-    <Reference Include="ScriptHookVDotNet2, Version=2.10.3.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>D:\Program Files (x86)\SteamLibrary\steamapps\common\Grand Theft Auto V\ScriptHookVDotNet2.dll</HintPath>
+      <HintPath>C:\Program Files\Rockstar Games\Grand Theft Auto V\ScriptHookVDotNet2.dll</HintPath>
     </Reference>
     <Reference Include="SharpDX, Version=3.1.1.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpDX.3.1.1\lib\net45\SharpDX.dll</HintPath>
@@ -114,10 +111,10 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="VAutodrive">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Grand Theft Auto V\scripts\VAutodrive.dll</HintPath>
+      <HintPath>C:\Program Files\Rockstar Games\Grand Theft Auto V\Scripts\VAutodrive.dll</HintPath>
     </Reference>
     <Reference Include="VCommonFunctions">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Grand Theft Auto V\scripts\VCommonFunctions.dll</HintPath>
+      <HintPath>C:\Program Files\Rockstar Games\Grand Theft Auto V\Scripts\VCommonFunctions.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/native/src/export.cpp
+++ b/native/src/export.cpp
@@ -44,7 +44,8 @@ static time_point<high_resolution_clock> last_constant_time;
 static void unpack_depth(ID3D11Device* dev, ID3D11DeviceContext* ctx, ID3D11Resource* src, vector<unsigned char>& dst, vector<unsigned char>& stencil)
 {
 	HRESULT hr = S_OK;
-
+	int screenResX;
+	int screenResY;
 	ComPtr<ID3D11Texture2D> src_tex;
 	
 	hr = src->QueryInterface(__uuidof(ID3D11Texture2D), &src_tex);
@@ -57,17 +58,41 @@ static void unpack_depth(ID3D11Device* dev, ID3D11DeviceContext* ctx, ID3D11Reso
 	if (hr != S_OK) throw std::system_error(hr, std::system_category());
 	if (dst.size() != src_desc.Height * src_desc.Width * 4) dst = vector<unsigned char>(src_desc.Height * src_desc.Width * 4);
 	if (stencil.size() != src_desc.Height * src_desc.Width) stencil = vector<unsigned char>(src_desc.Height * src_desc.Width);
-	for (int x = 0; x < src_desc.Width; ++x)
+	
+	if (screenResX >= src_desc.Width)
 	{
-		for (int y = 0; y < src_desc.Height; ++y)
+		for (int x = 0; x < src_desc.Width; ++x)
 		{
-			const float* src_f = (const float*)((const char*)src_map.pData + src_map.RowPitch*y + (x * 8));
-			unsigned char* dst_p = &dst[src_desc.Width * 4 * y + (x * 4)];
-			unsigned char* stencil_p = &stencil[src_desc.Width * y + x];
-			memmove(dst_p, src_f, 4);
-			memmove(stencil_p, src_f + 1, 1);
+			for (int y = 0; y < src_desc.Height; ++y)
+			{
+				const float* src_f = (const float*)((const char*)src_map.pData + src_map.RowPitch*y + (x * 8));
+				unsigned char* dst_p = &dst[src_desc.Width * 4 * y + (x * 4)];
+				unsigned char* stencil_p = &stencil[src_desc.Width * y + x];
+				memmove(dst_p, src_f, 4);
+				memmove(stencil_p, src_f + 1, 1);
+			}
 		}
 	}
+	else
+	{
+		// resample, for when depth map is bigger than screen image.
+		float scale = ((float) src_desc.Width) / ((float) screenResX);
+		dst = vector<unsigned char>(screenResY * screenResX * 4);
+		for (int x = 0; x < screenResX; ++x) // screenResX
+		{
+			for (int y = 0; y < screenResY; ++y) //screenResY
+			{
+				int scaledX = int(x*scale);
+				int scaledY = int(y*scale);
+				const float* src_f = (const float*)((const char*)src_map.pData + int(src_map.RowPitch*scaledY + (scaledX * 8)));
+				unsigned char* dst_p = &dst[screenResX * 4 * y + (x * 4)];
+				unsigned char* stencil_p = &stencil[screenResX * y + x];
+				memmove(dst_p, src_f, 4);
+				memmove(stencil_p, src_f + 1, 1);
+			}
+		}
+	}
+		
 	ctx->Unmap(src, 0);
 }
 static ComPtr<ID3D11Texture2D> CreateTexHelper(ID3D11Device* dev, DXGI_FORMAT fmt, int width, int height, int samples)

--- a/native/src/export.cpp
+++ b/native/src/export.cpp
@@ -77,13 +77,14 @@ static void unpack_depth(ID3D11Device* dev, ID3D11DeviceContext* ctx, ID3D11Reso
 	{
 		// resample, for when depth map is bigger than screen image.
 		float scale = ((float) src_desc.Width) / ((float) screenResX);
+		int scaledX = int(x*scale);
+		int scaledY = int(y*scale);
 		dst = vector<unsigned char>(screenResY * screenResX * 4);
+
 		for (int x = 0; x < screenResX; ++x) // screenResX
 		{
 			for (int y = 0; y < screenResY; ++y) //screenResY
 			{
-				int scaledX = int(x*scale);
-				int scaledY = int(y*scale);
 				const float* src_f = (const float*)((const char*)src_map.pData + int(src_map.RowPitch*scaledY + (scaledX * 8)));
 				unsigned char* dst_p = &dst[screenResX * 4 * y + (x * 4)];
 				unsigned char* stencil_p = &stencil[screenResX * y + x];

--- a/native/src/export.cpp
+++ b/native/src/export.cpp
@@ -77,14 +77,15 @@ static void unpack_depth(ID3D11Device* dev, ID3D11DeviceContext* ctx, ID3D11Reso
 	{
 		// resample, for when depth map is bigger than screen image.
 		float scale = ((float) src_desc.Width) / ((float) screenResX);
-		int scaledX = int(x*scale);
-		int scaledY = int(y*scale);
 		dst = vector<unsigned char>(screenResY * screenResX * 4);
 
 		for (int x = 0; x < screenResX; ++x) // screenResX
 		{
+			int scaledX = int(x*scale);
+			
 			for (int y = 0; y < screenResY; ++y) //screenResY
 			{
+				int scaledY = int(y*scale);
 				const float* src_f = (const float*)((const char*)src_map.pData + int(src_map.RowPitch*scaledY + (scaledX * 8)));
 				unsigned char* dst_p = &dst[screenResX * 4 * y + (x * 4)];
 				unsigned char* stencil_p = &stencil[screenResX * y + x];


### PR DESCRIPTION
Modification to export.cpp unpack_depth() to down sample the depth map to the same size as the captured GTAV window image, only when the depth buffer is larger than the captured window. Fixes issue #28 . Works stand alone and with managed code.

Could probably be better implemented, uses mixed data types for scaling. Suggest you test on your machine before merging the pull request @barcharcraz .